### PR TITLE
feat: factory registrations

### DIFF
--- a/src/GroveGames.DependencyInjection/ContainerConfigurer.cs
+++ b/src/GroveGames.DependencyInjection/ContainerConfigurer.cs
@@ -31,6 +31,12 @@ internal sealed class ContainerConfigurer : IContainerConfigurer
         AddSingleton(registrationType, registrationType, objectResolver);
     }
 
+    public void AddSingleton(Type registrationType, Func<object> factory)
+    {
+        var objectResolver = new FactoryObjectResolver(factory, _containerResolver, _disposableCollection);
+        AddSingleton(registrationType, registrationType, objectResolver);
+    }
+
     public void AddSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType)
     {
         var objectResolver = new UninitializedObjectResolver(implementationType, _containerResolver, _disposableCollection);

--- a/src/GroveGames.DependencyInjection/ContainerConfigurer.cs
+++ b/src/GroveGames.DependencyInjection/ContainerConfigurer.cs
@@ -31,23 +31,34 @@ internal sealed class ContainerConfigurer : IContainerConfigurer
         AddSingleton(registrationType, registrationType, objectResolver);
     }
 
-    public void AddSingleton(Type registrationType, Func<object> factory)
-    {
-        var objectResolver = new FactoryObjectResolver(factory, _containerResolver, _disposableCollection);
-        AddSingleton(registrationType, registrationType, objectResolver);
-    }
-
     public void AddSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType)
     {
         var objectResolver = new UninitializedObjectResolver(implementationType, _containerResolver, _disposableCollection);
         AddSingleton(registrationType, registrationType, objectResolver);
     }
 
-    public void AddTransient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType)
+    public void AddSingleton(Type registrationType, Func<object> factory)
     {
-        var objectResolver = new UninitializedObjectResolver(implementationType, _containerResolver, _disposableCollection);
+        var objectResolver = new FactoryObjectResolver(factory, _containerResolver, _disposableCollection);
+        AddSingleton(registrationType, registrationType, objectResolver);
+    }
+
+    private void AddTransient(Type registrationType, Type implementationType, IObjectResolver objectResolver)
+    {
         var instanceResolver = new TransientResolver(objectResolver);
         _containerResolver.AddInstanceResolver(registrationType, instanceResolver);
         _initializableCollection.TryAdd(registrationType, implementationType);
+    }
+
+    public void AddTransient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType)
+    {
+        var objectResolver = new UninitializedObjectResolver(implementationType, _containerResolver, _disposableCollection);
+        AddTransient(registrationType, implementationType, objectResolver);
+    }
+
+    public void AddTransient(Type registrationType, Func<object> factory)
+    {
+        var objectResolver = new FactoryObjectResolver(factory, _containerResolver, _disposableCollection);
+        AddTransient(registrationType, registrationType, objectResolver);
     }
 }

--- a/src/GroveGames.DependencyInjection/ContainerConfigurerExtensions.cs
+++ b/src/GroveGames.DependencyInjection/ContainerConfigurerExtensions.cs
@@ -28,13 +28,6 @@ public static class ContainerConfigurerExtensions
         containerConfigurer.AddSingleton(registrationType, implementationInstance);
     }
 
-    public static void AddSingleton<TRegistration>(this IContainerConfigurer containerConfigurer, Func<TRegistration> factory)
-    where TRegistration : class
-    {
-        var registrationType = typeof(TRegistration);
-        containerConfigurer.AddSingleton(registrationType, factory);
-    }
-
     public static void AddSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TRegistration, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TImplementation>(this IContainerConfigurer containerConfigurer)
         where TRegistration : class
         where TImplementation : class, TRegistration
@@ -58,6 +51,13 @@ public static class ContainerConfigurerExtensions
         containerConfigurer.AddSingleton(implementationType, implementationType);
     }
 
+    public static void AddSingleton<TRegistration>(this IContainerConfigurer containerConfigurer, Func<TRegistration> factory)
+        where TRegistration : class
+    {
+        var registrationType = typeof(TRegistration);
+        containerConfigurer.AddSingleton(registrationType, factory);
+    }
+
     public static void AddTransient<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TRegistration, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TImplementation>(this IContainerConfigurer containerConfigurer)
         where TRegistration : class
         where TImplementation : class, TRegistration
@@ -72,5 +72,12 @@ public static class ContainerConfigurerExtensions
     {
         var implementationType = typeof(TImplementation);
         containerConfigurer.AddTransient(implementationType, implementationType);
+    }
+
+    public static void AddTransient<TRegistration>(this IContainerConfigurer containerConfigurer, Func<TRegistration> factory)
+    where TRegistration : class
+    {
+        var registrationType = typeof(TRegistration);
+        containerConfigurer.AddTransient(registrationType, factory);
     }
 }

--- a/src/GroveGames.DependencyInjection/ContainerConfigurerExtensions.cs
+++ b/src/GroveGames.DependencyInjection/ContainerConfigurerExtensions.cs
@@ -28,6 +28,13 @@ public static class ContainerConfigurerExtensions
         containerConfigurer.AddSingleton(registrationType, implementationInstance);
     }
 
+    public static void AddSingleton<TRegistration>(this IContainerConfigurer containerConfigurer, Func<TRegistration> factory)
+    where TRegistration : class
+    {
+        var registrationType = typeof(TRegistration);
+        containerConfigurer.AddSingleton(registrationType, factory);
+    }
+
     public static void AddSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TRegistration, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TImplementation>(this IContainerConfigurer containerConfigurer)
         where TRegistration : class
         where TImplementation : class, TRegistration

--- a/src/GroveGames.DependencyInjection/IContainerConfigurer.cs
+++ b/src/GroveGames.DependencyInjection/IContainerConfigurer.cs
@@ -7,5 +7,7 @@ public interface IContainerConfigurer
     void AddSingleton(Type registrationType, object implementationInstance);
 
     void AddSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType);
+    void AddSingleton(Type registrationType, Func<object> factory);
     void AddTransient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type registrationType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType);
+    void AddTransient(Type registrationType, Func<object> factory);
 }

--- a/src/GroveGames.DependencyInjection/Resolution/FactoryObjectResolver.cs
+++ b/src/GroveGames.DependencyInjection/Resolution/FactoryObjectResolver.cs
@@ -1,0 +1,26 @@
+using GroveGames.DependencyInjection.Collections;
+using GroveGames.DependencyInjection.Injectors;
+
+namespace GroveGames.DependencyInjection.Resolution;
+
+internal sealed class FactoryObjectResolver : IObjectResolver
+{
+    private readonly Func<object> _factory;
+    private readonly IRegistrationResolver _registrationResolver;
+    private readonly IDisposableCollection _disposables;
+
+    public FactoryObjectResolver(Func<object> factory, IRegistrationResolver registrationResolver, IDisposableCollection disposables)
+    {
+        _factory = factory;
+        _registrationResolver = registrationResolver;
+        _disposables = disposables;
+    }
+
+    public object Resolve()
+    {
+        var instance = _factory.Invoke();
+        MethodInjector.Inject(instance, _registrationResolver);
+        _disposables.TryAdd(instance);
+        return instance;
+    }
+}

--- a/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerExtensionsTests.cs
+++ b/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerExtensionsTests.cs
@@ -102,4 +102,18 @@ public class ContainerConfigurerExtensionsTests
         // Assert
         mockContainerConfigurer.Verify(c => c.AddSingleton(typeof(MockInitializable), factory), Times.Once);
     }
+
+    [Fact]
+    public void AddTransient_Generic_WithFactory_ShouldAddTransientUsingFactory()
+    {
+        // Arrange
+        var mockContainerConfigurer = new Mock<IContainerConfigurer>();
+        Func<MockInitializable> factory = () => new MockInitializable();
+
+        // Act
+        mockContainerConfigurer.Object.AddTransient(factory);
+
+        // Assert
+        mockContainerConfigurer.Verify(c => c.AddTransient(typeof(MockInitializable), factory), Times.Once);
+    }
 }

--- a/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerExtensionsTests.cs
+++ b/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerExtensionsTests.cs
@@ -88,4 +88,18 @@ public class ContainerConfigurerExtensionsTests
         // Assert
         mockContainerConfigurer.Verify(c => c.AddSingleton(typeof(IInitializable), instance), Times.Once);
     }
+
+    [Fact]
+    public void AddSingleton_Generic_WithFactory_ShouldAddSingletonUsingFactory()
+    {
+        // Arrange
+        var mockContainerConfigurer = new Mock<IContainerConfigurer>();
+        Func<MockInitializable> factory = () => new MockInitializable();
+
+        // Act
+        mockContainerConfigurer.Object.AddSingleton(factory);
+
+        // Assert
+        mockContainerConfigurer.Verify(c => c.AddSingleton(typeof(MockInitializable), factory), Times.Once);
+    }
 }

--- a/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerTests.cs
+++ b/tests/GroveGames.DependencyInjection.Tests/ContainerConfigurerTests.cs
@@ -105,4 +105,52 @@ public class ContainerConfigurerTests
         Assert.False(factoryInvoked, "Factory should not be invoked during registration");
         mockContainerResolver.Verify(r => r.AddInstanceResolver(registrationType, It.IsAny<SingletonResolver>()), Times.Once);
     }
+
+    [Fact]
+    public void AddTransient_WithFactory_ShouldAddTransientResolverUsingFactory()
+    {
+        // Arrange
+        var registrationType = typeof(object);
+        var mockContainerResolver = new Mock<IContainerResolver>();
+        var mockInitializableCollection = new Mock<IInitializableCollection>();
+        var mockDisposableCollection = new Mock<IDisposableCollection>();
+        var factory = new Func<object>(() => new object());
+        var containerConfigurer = new ContainerConfigurer(mockContainerResolver.Object, mockInitializableCollection.Object, mockDisposableCollection.Object);
+
+        // Act
+        containerConfigurer.AddTransient(registrationType, factory);
+
+        // Assert
+        mockContainerResolver.Verify(r => r.AddInstanceResolver(registrationType, It.IsAny<TransientResolver>()), Times.Once);
+        mockInitializableCollection.Verify(i => i.TryAdd(registrationType, registrationType), Times.Once);
+    }
+
+    [Fact]
+    public void AddTransient_WithFactory_ShouldCreateNewInstanceEachTime()
+    {
+        // Arrange
+        var registrationType = typeof(object);
+        var mockContainerResolver = new Mock<IContainerResolver>();
+        var mockInitializableCollection = new Mock<IInitializableCollection>();
+        var mockDisposableCollection = new Mock<IDisposableCollection>();
+        var instanceCount = 0;
+        var factory = new Func<object>(() =>
+        {
+            instanceCount++;
+            return new object();
+        });
+
+        var containerConfigurer = new ContainerConfigurer(mockContainerResolver.Object, mockInitializableCollection.Object, mockDisposableCollection.Object);
+
+        // Act
+        containerConfigurer.AddTransient(registrationType, factory);
+
+        // Simulate multiple resolutions
+        factory();
+        factory();
+
+        // Assert
+        Assert.Equal(2, instanceCount);
+        mockContainerResolver.Verify(r => r.AddInstanceResolver(registrationType, It.IsAny<TransientResolver>()), Times.Once);
+    }
 }

--- a/tests/GroveGames.DependencyInjection.Tests/Resolution/FactoryObjectResolverTests.cs
+++ b/tests/GroveGames.DependencyInjection.Tests/Resolution/FactoryObjectResolverTests.cs
@@ -3,7 +3,7 @@ using GroveGames.DependencyInjection.Resolution;
 
 namespace GroveGames.DependencyInjection.Tests.Resolution;
 
-public class InitializedObjectResolverTests
+public class FactoryObjectResolverTests
 {
     private class TestClassWithInjectMethod : IDisposable
     {
@@ -25,14 +25,15 @@ public class InitializedObjectResolverTests
     }
 
     [Fact]
-    public void Resolve_ShouldReturnImplementationInstance()
+    public void Resolve_ShouldInvokeFactory()
     {
         // Arrange
         var mockImplementation = new TestClassWithInjectMethod();
         var mockRegistrationResolver = new Mock<IRegistrationResolver>();
         var mockDisposableCollection = new Mock<IDisposableCollection>();
-        var objectResolver = new InitializedObjectResolver(
-            mockImplementation,
+        var factory = new Func<object>(() => mockImplementation);
+        var objectResolver = new FactoryObjectResolver(
+            factory,
             mockRegistrationResolver.Object,
             mockDisposableCollection.Object
         );
@@ -53,8 +54,9 @@ public class InitializedObjectResolverTests
         var mockRegistrationResolver = new Mock<IRegistrationResolver>();
         mockRegistrationResolver.Setup(r => r.Resolve(It.IsAny<Type>())).Returns("InjectedString");
         var mockDisposableCollection = new Mock<IDisposableCollection>();
-        var objectResolver = new InitializedObjectResolver(
-            mockImplementation,
+        var factory = new Func<object>(() => mockImplementation);
+        var objectResolver = new FactoryObjectResolver(
+            factory,
             mockRegistrationResolver.Object,
             mockDisposableCollection.Object
         );
@@ -74,8 +76,9 @@ public class InitializedObjectResolverTests
         var mockImplementation = new TestClassWithInjectMethod();
         var mockRegistrationResolver = new Mock<IRegistrationResolver>();
         var mockDisposableCollection = new Mock<IDisposableCollection>();
-        var objectResolver = new InitializedObjectResolver(
-            mockImplementation,
+        var factory = new Func<object>(() => mockImplementation);
+        var objectResolver = new FactoryObjectResolver(
+            factory,
             mockRegistrationResolver.Object,
             mockDisposableCollection.Object
         );


### PR DESCRIPTION
Usage:

```csharp
public interface IRepository<T>
{
    void Add(T item);
}

public class Repository<T> : IRepository<T>
{
    private readonly List<T> _items = new List<T>();
    public void Add(T item) => _items.Add(item);
}

public class Service<T>
{
    private readonly IRepository<T> _repository;
    public Service(IRepository<T> repository)
    {
        _repository = repository;
    }

    public void ProcessItem(T item)
    {
        _repository.Add(item);
        Console.WriteLine($"{typeof(T).Name} processed.");
    }
}

// Registration with generic factory
containerConfigurer.AddSingleton<IRepository<int>>(() => new Repository<int>());
containerConfigurer.AddTransient<Service<int>>(() => 
    new Service<int>(containerConfigurer.Resolve<IRepository<int>>()));
```